### PR TITLE
Throw Exception with Zendesk error response

### DIFF
--- a/src/services/ZendeskService.php
+++ b/src/services/ZendeskService.php
@@ -72,7 +72,7 @@ class ZendeskService extends Component
 		$output = self::curlWrap("/tickets.json", $create, $headers);
 		
 		//get the ticket ID - also checks the new ticket was created successfully
-                if($output->error) {
+                if(!empty($output->error)) {
                         throw new \Exception('Zendesk Error: ' . $output->error);
                 }
                 $ticketId = $output->ticket ? $output->ticket->id : null;

--- a/src/services/ZendeskService.php
+++ b/src/services/ZendeskService.php
@@ -72,7 +72,10 @@ class ZendeskService extends Component
 		$output = self::curlWrap("/tickets.json", $create, $headers);
 		
 		//get the ticket ID - also checks the new ticket was created successfully
-		$ticketId = $output->ticket->id;
+                if($output->error) {
+                        throw new \Exception('Zendesk Error: ' . $output->error);
+                }
+                $ticketId = $output->ticket ? $output->ticket->id : null;
 		
 		//if return exists and we've a ticket ID - it must have been created successfully :-)
 		if ($output && $ticketId) {


### PR DESCRIPTION
The API responds with things like 
```json
{"error": "Couldn't authenticate you."}
```
The plugin should surface these errors. Currently it throws an error that ticket->id is not found, which causes a 500 when devmode is off, with no useful logging.